### PR TITLE
Add support for Pale Moon 27.1+

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,10 @@
 {
   "title": "Reload Plus",
   "version": "5.1.0",
+  "engines": {
+      "firefox": ">=38.0a1",
+      "{8de7fcbb-c55c-4fbe-bfc5-fc555c87dbc4}": ">=27.1.0b1"
+   },
   "author": "bwProductions",
   "description": "Supercharge your reload button and hotkeys!",
   "homepage": "https://github.com/blackwind/reload-plus/issues",


### PR DESCRIPTION
Based on [PMkit documentation draft v1.1](https://github.com/JustOff/pm27-sdk-addons/blob/master/PMkit.md), tested with [Pale Moon 27.1.0beta](https://forum.palemoon.org/viewtopic.php?f=1&t=14455).